### PR TITLE
Fix for terminal component pages that lack containers..

### DIFF
--- a/public/models/aeon_record_mapper.rb
+++ b/public/models/aeon_record_mapper.rb
@@ -407,8 +407,8 @@ class AeonRecordMapper
         Rails.logger.info("Aeon Fulfillment Plugin") { "Checking \"#{current_uri}\" for Top Container instances..." }
         Rails.logger.debug("Aeon Fulfillment Plugin") { "#{record_json.to_json}" }
 
-        #this whole bit about inheriting containers doesn't work with our other plugin, so just skipping it for now.
-        #the container pges will still get a few checks below, but those will always evaluate to false.
+        #this whole bit about inheriting containers doesn't work with our other plugin (it gets passed an empty array which will error later), so just skipping it for now.
+        #the container pages will still get a few checks below, but those will always evaluate to false.
         unless record.is_a?(Container)
           instances = record_json['instances']
               .reject { |instance| instance['digital_object'] }

--- a/public/models/aeon_record_mapper.rb
+++ b/public/models/aeon_record_mapper.rb
@@ -407,8 +407,11 @@ class AeonRecordMapper
         Rails.logger.info("Aeon Fulfillment Plugin") { "Checking \"#{current_uri}\" for Top Container instances..." }
         Rails.logger.debug("Aeon Fulfillment Plugin") { "#{record_json.to_json}" }
 
-        #this whole bit about inheriting containers doesn't work with our other plugin (it gets passed an empty array which will error later), so just skipping it for now.
-        #the container pages will still get a few checks below, but those will always evaluate to false.
+        # Inheriting containers doesn't work with our other plugin 
+        # (it gets passed an empty array that will cause an error later), 
+        # so just skipping those for now.
+        # The container pages will still get a few checks below, 
+        # but those will always evaluate to false.
         unless record.is_a?(Container)
           instances = record_json['instances']
               .reject { |instance| instance['digital_object'] }

--- a/public/models/aeon_record_mapper.rb
+++ b/public/models/aeon_record_mapper.rb
@@ -407,14 +407,13 @@ class AeonRecordMapper
         Rails.logger.info("Aeon Fulfillment Plugin") { "Checking \"#{current_uri}\" for Top Container instances..." }
         Rails.logger.debug("Aeon Fulfillment Plugin") { "#{record_json.to_json}" }
 
-        if record_json['instances'].present?
+        #this whole bit about inheriting containers doesn't work with our other plugin, so just skipping it for now.
+        #the container pges will still get a few checks below, but those will always evaluate to false.
+        unless record.is_a?(Container)
           instances = record_json['instances']
               .reject { |instance| instance['digital_object'] }
-        end
-
-        if instances.try(:any?)
-            Rails.logger.info("Aeon Fulfillment Plugin") { "Top Container instances found" }
-            return instances
+          Rails.logger.info("Aeon Fulfillment Plugin") { "Top Container instances found" }
+          return instances
         end
 
         parent_uri = ''

--- a/public/models/aeon_record_mapper.rb
+++ b/public/models/aeon_record_mapper.rb
@@ -407,11 +407,12 @@ class AeonRecordMapper
         Rails.logger.info("Aeon Fulfillment Plugin") { "Checking \"#{current_uri}\" for Top Container instances..." }
         Rails.logger.debug("Aeon Fulfillment Plugin") { "#{record_json.to_json}" }
 
-        # Inheriting containers doesn't work with our other plugin 
-        # (it gets passed an empty array that will cause an error later), 
-        # so just skipping those for now.
-        # The container pages will still get a few checks below, 
-        # but those will always evaluate to false.
+        # Inheriting containers doesn't work with our other plugin (it gets passed an
+        # empty array that will cause an error later), so just skipping those for now.
+        # TODO: Figure out why the other plugin does not work with this new feature
+        
+        # The container pages will still get a few checks below, but those will always
+        # evaluate to false.
         unless record.is_a?(Container)
           instances = record_json['instances']
               .reject { |instance| instance['digital_object'] }


### PR DESCRIPTION
yet have ancestors with containers.

Example component that does NOT load now: https://archives.yale.edu/repositories/11/archival_objects/255230

This update is a temporary patch to fix that issue.  